### PR TITLE
Made rollbacks possible with clojure magic

### DIFF
--- a/src/malachite_migrations/db.clj
+++ b/src/malachite_migrations/db.clj
@@ -55,18 +55,28 @@
     ; loop over all the columns, accumulating the SQL string as we go
     (add-cols-to-sql columns base-sql-str)))
 
-; TODO- add ! to these functions which have side-effects
-(defn drop-table 
+(defn drop-table! 
   "Drops table with a given table name"
   [table-name]
   (db/execute!
     (:url db-config)
     [(str "DROP TABLE IF EXISTS " table-name ";")]))
 
-; TODO- add ! to these functions which have side-effects
-(defn create-table
+(defn create-table!
   "Creates a table on the DB specified in the config hash"
   [table-name columns]
    (db/execute!
      (:url db-config)
      [(create-table-sql table-name columns)]))
+
+(defn create-table
+  "Generates a function which chooses between the creation
+   and destruction of a table depending on whether :up or :down
+   is passed to it"
+  [table-name columns]
+  (fn [symbol]
+    (cond
+     (= :up symbol)
+       (create-table! table-name columns)
+     (= :down symbol)
+       (drop-table! table-name))))

--- a/src/malachite_migrations/manager.clj
+++ b/src/malachite_migrations/manager.clj
@@ -8,7 +8,7 @@
   "Creates the malachite-migrations table on the database if it doesn't exist"
   []
   (when-not (table-exists? "malachite_migrations")
-    (do (create-table "malachite_migrations" [[:timestamp :bigint]])
+    (do (create-table! "malachite_migrations" [[:timestamp :bigint]])
         nil)))
 
 (defn- migrations
@@ -16,6 +16,7 @@
   []
   (map #(.getPath %) (rest (file-seq (as-file "migrations/")))))
 
+;; TODO: Implement grabbing latest timestamp from db, right now hardcoded
 (defn- pending-migrations
   "Grabs all migration file paths which have not yet been run by checking
    for the most recently ran migration's timestamp in the migrations table
@@ -59,13 +60,14 @@
     (if-not (empty? pending-migrations)
       ; run all migrations; if they succeed, write the timestamp to the database
       (doseq [mig pending-migrations]
-        (load-file mig)
+        ((load-file mig) :up)
         (write-timestamp! (get-timestamp mig)))
       (println "No pending migrations."))))
 
 (defn rollback!
   "Undoes the latest migration and removes that timestamp from the database"
   []
+  ()
   nil)
 
 (defn migrate-to!

--- a/test/malachite_migrations/db_test.clj
+++ b/test/malachite_migrations/db_test.clj
@@ -19,12 +19,12 @@
 (expect (table-exists? "users_db") false)
 
 ; DB Integration Tests
-(expect (create-table "users_db" 
+(expect (create-table! "users_db" 
                       [[:id :integer]
                       [:name :string]]))
 
 (expect (table-exists? "users_db") true)
 
-(expect (drop-table "users_db"))
+(expect (drop-table! "users_db"))
 
 (expect (table-exists? "users_db") false)

--- a/test/malachite_migrations/manager_migrations_test.clj
+++ b/test/malachite_migrations/manager_migrations_test.clj
@@ -39,11 +39,11 @@
   ;; clean up the files generated 
   (delete-file fpath)
   (delete-file fpath1))
-  (drop-table "malachite_migrations")
+  (drop-table! "malachite_migrations")
 
 (defn clean-up-mng-test
   {:expectations-options :after-run}
   []
-  (drop-table "users_mng")
-  (drop-table "users_mig_mng")
-  (drop-table "users_mig_mng1"))
+  (drop-table! "users_mng")
+  (drop-table! "users_mig_mng")
+  (drop-table! "users_mig_mng1"))


### PR DESCRIPTION
Replaced impure implementation of create-table with a
good old function that returns a function.  Depending on
whether :up or :down is passed, it will implement the
migrate and rollback functionality of creating a database
table.