### PR TITLE
Passed in db-config to as a parameter

### DIFF
--- a/src/malachite_migrations/manager.clj
+++ b/src/malachite_migrations/manager.clj
@@ -23,21 +23,21 @@
 
 (defn delete-timestamp!
   "Removes a given timestamp from the migrations database table"
-  [timestamp]
+  [db-config timestamp]
   (db/execute!
    (:url db-config)
    ["DELETE FROM malachite_migrations WHERE malachite_migrations.timestamp = ?;" timestamp]))
 
 (defn write-timestamp!
   "Writes the timestamp to the database when the migration has been handled"
-  [timestamp]
+  [db-config timestamp]
   (db/execute!
    (:url db-config)
    ["INSERT INTO malachite_migrations (timestamp) VALUES(?);" timestamp]))
 
 (defn current-timestamp
   "Grabs the latest timestamp in the database"
-  []
+  [db-config]
   (:timestamp
     (first
      (db/query
@@ -47,26 +47,26 @@
 
 (defn migrate!
   "Runs all migrations created after the latest timestamp in the database"
-  []
-  (let [ct (or (current-timestamp) 0)
+  [db-config]
+  (let [ct (or (current-timestamp db-config) 0)
         pending-migrations (pending-migrations (migrations))]
     (if-not (empty? pending-migrations)
       ; run all migrations; if they succeed, write the timestamp to the database
       (doseq [mig pending-migrations]
-        ((load-file mig) :up)
-        (write-timestamp! (get-timestamp mig)))
+        ((load-file mig) db-config :up)
+        (write-timestamp! db-config (get-timestamp mig)))
       (println "No pending migrations."))))
 
 (defn rollback!
   "Undoes the latest migration and removes that timestamp from the database"
-  []
-  (let [ct (current-timestamp)]
+  [db-config]
+  (let [ct (current-timestamp db-config)]
     (cond
      (nil? ct)
      nil
      (not (nil? ct))
      (do ((load-file (migration ct)) :down)
-         (delete-timestamp! ct)))))
+         (delete-timestamp! db-config ct)))))
 
 (defn migrate-to!
   "Runs all migrations between the latest timestamp in the d

--- a/test/malachite_migrations/db_test.clj
+++ b/test/malachite_migrations/db_test.clj
@@ -4,6 +4,11 @@
             [clojure.java.jdbc :as db]
             [malachite-migrations.helpers :refer :all]))
 
+(def db-config 
+  {
+   :url "jdbc:postgresql://localhost/test-migrations"
+   })
+
 ; SQL Generation Tests
 (expect (.contains (create-table-sql "users_db" [[:id :integer] [:name :string]]) 
   "id INTEGER"))
@@ -17,24 +22,24 @@
 (expect (.contains (create-table-sql "users_db" [[:id :string] [:name :string]]) 
   "name VARCHAR(64)"))
 
-(expect (table-exists? "users_db") false)
+(expect (table-exists? db-config "users_db") false)
 
 ; DB Integration Tests
-(expect (create-table! "users_db" 
+(expect (create-table! db-config "users_db" 
                       [[:id :integer]
                       [:name :string]]))
 
-(expect (table-exists? "users_db") true)
-(expect (column-exists? "users_db" "id") true)
-(expect (column-exists? "users_db" "name") true)
+(expect (table-exists? db-config "users_db") true)
+(expect (column-exists? db-config "users_db" "id") true)
+(expect (column-exists? db-config "users_db" "name") true)
 
-(expect (add-column! "users_db" [:email :string]))
-(expect (column-exists? "users_db" "email") true)
+(expect (add-column! db-config "users_db" [:email :string]))
+(expect (column-exists? db-config "users_db" "email") true)
 
 
-(expect (remove-column! "users_db" :email))
-(expect (column-exists? "users_db" "email") false)
+(expect (remove-column! db-config "users_db" :email))
+(expect (column-exists? db-config "users_db" "email") false)
 
-(expect (drop-table! "users_db"))
+(expect (drop-table! db-config "users_db"))
 
-(expect (table-exists? "users_db") false)
+(expect (table-exists? db-config "users_db") false)

--- a/test/malachite_migrations/helpers.clj
+++ b/test/malachite_migrations/helpers.clj
@@ -4,7 +4,7 @@
 
 (defn table-exists?
   "Checks if a table with a given tablename exists"
-  [table-name]
+  [db-config table-name]
   (:exists (first (db/query
               (:url db-config)
               [(str "SELECT EXISTS(
@@ -16,14 +16,14 @@
 
 (defn write-migrations-table!
   "Creates the malachite-migrations table on the database if it doesn't exist"
-  []
-  (when-not (table-exists? "malachite_migrations")
-    (do (create-table! "malachite_migrations" [[:timestamp :bigint]])
+  [db-config]
+  (when-not (table-exists? db-config "malachite_migrations")
+    (do (create-table! db-config "malachite_migrations" [[:timestamp :bigint]])
         nil)))
 
 (defn delete-all-migrations!
   "Deletes all records in the malachite-migrations table"
-  []
+  [db-config]
   (db/execute!
    (:url db-config)
    ["DELETE FROM malachite_migrations"]))

--- a/test/malachite_migrations/manager_migrations_test.clj
+++ b/test/malachite_migrations/manager_migrations_test.clj
@@ -6,25 +6,29 @@
             [malachite-migrations.db :refer :all]
             [malachite-migrations.core :refer :all]))
 
+(def db-config 
+  {
+   :url "jdbc:postgresql://localhost/test-migrations"
+   })
 
-(write-migrations-table!)
+(write-migrations-table! db-config)
 
 ;; When there are no migrations, migrate should return nil and not fail
-(expect nil (migrate!))
+(expect nil (migrate! db-config))
 
 (let [fpath (generate-migration "create_users"
                                 "users_mng"
                                 :create-table
                                 [:id :integer]
                                 [:name :string])] 
-  (migrate!)
+  (migrate! db-config)
   ;; (expect (table-exists? "users_mng"))
   (delete-file fpath))
 
-(let [ct (current-timestamp)]
+(let [ct (current-timestamp db-config)]
 ;  the current timestamp should be a number
   (expect (number? ct))
-  (delete-timestamp! ct))
+  (delete-timestamp! db-config ct))
 
 (let [fpath (generate-migration "create_users_mig_mng"
                                 "users_mig_mng"
@@ -36,7 +40,7 @@
                                 :create-table
                                 [:id :integer]
                                 [:name :string])]
-  (migrate!)
+  (migrate! db-config)
   ;; migrate! should create both tables
   ;(expect (table-exists? "users_mig_mng"))
   ;(expect (table-exists? "users_mig_mng1"))
@@ -47,6 +51,6 @@
 (defn clean-up-mng-test
   {:expectations-options :after-run}
   []
-  (drop-table! "users_mng")
-  (drop-table! "users_mig_mng")
-  (drop-table! "users_mig_mng1"))
+  (drop-table! db-config "users_mng")
+  (drop-table! db-config "users_mig_mng")
+  (drop-table! db-config "users_mig_mng1"))

--- a/test/malachite_migrations/manager_timestamp_test.clj
+++ b/test/malachite_migrations/manager_timestamp_test.clj
@@ -6,18 +6,23 @@
             [malachite-migrations.db :refer :all]
             [malachite-migrations.core :refer :all]))
 
-(delete-all-migrations!)
+(def db-config 
+  {
+   :url "jdbc:postgresql://localhost/test-migrations"
+   })
+
+(delete-all-migrations! db-config)
 ;; Test reading and writing of timestamps to the migrations table
-(write-timestamp! 100)
-(write-timestamp! 101)
+(write-timestamp! db-config 100)
+(write-timestamp! db-config 101)
 
-(let [ct (current-timestamp)]
+(let [ct (current-timestamp db-config)]
   (expect 101 ct))
-(delete-timestamp! 101)
+(delete-timestamp! db-config 101)
 
-(let [ct (current-timestamp)]
+(let [ct (current-timestamp db-config)]
   (expect 100 ct))
 
-(delete-timestamp! 100)
+(delete-timestamp! db-config 100)
 
-(expect (nil? (current-timestamp)))
+(expect (nil? (current-timestamp db-config)))


### PR DESCRIPTION
We removed db-config as an a global variable and passed it into any functions interacting with the database. Not sure if this change is a keeper, but a good experiment exercising functional principles.