### PR TITLE
Naive add and remove index added

### DIFF
--- a/test/malachite_migrations/db_test.clj
+++ b/test/malachite_migrations/db_test.clj
@@ -36,6 +36,18 @@
 (expect (add-column! db-config "users_db" [:email :string]))
 (expect (column-exists? db-config "users_db" "email") true)
 
+(expect (add-index! db-config "users_db" [:email]))
+(expect (index-exists? db-config "users_db_email_idx") true)
+(expect (remove-index! db-config "users_db" [:email]))
+(expect (index-exists? db-config "users_db_email_idx") false)
+
+;; index functionality using the :up :down wrapper
+(let [add-users-db-email-idx (add-index "users_db" [:email])]
+  (expect (add-users-db-email-idx db-config :up))
+  (expect (index-exists? db-config "users_db_email_idx") true)
+  (expect (add-users-db-email-idx db-config :down))
+  (expect (index-exists? db-config "users_db_email_idx") false))
+
 
 (expect (remove-column! db-config "users_db" :email))
 (expect (column-exists? db-config "users_db" "email") false)

--- a/test/malachite_migrations/helpers.clj
+++ b/test/malachite_migrations/helpers.clj
@@ -14,6 +14,17 @@
                     table_name = '" table-name "'
                 );")]))))
 
+(defn index-exists?
+  "Checks whether a given index exists"
+  [db-config index-name]
+  (:exists (first (db/query
+                   (:url db-config)
+                   [(str "SELECT EXISTS (
+SELECT 1
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname = '" index-name "');")]))))
+
 (defn write-migrations-table!
   "Creates the malachite-migrations table on the database if it doesn't exist"
   [db-config]


### PR DESCRIPTION
You can now naively add and remove indexes. Added a PostgreSQL extension to our DSL that lets you add an index on a table and a set of it's columns.  You can also specify binary flags and any non-binary flags with a default (right now this is just ASC / DESC).

If an index on these columns already exists, you'll get an index name like "tablename_column1_column2_idx1" in postgres. There isn't any checking for this, so for now using this you'd be careful not to create two indexes on the same table/columns, you'll have to manually delete any above the first one and add-index :down will throw unexpected errors.
